### PR TITLE
Make C++ testing work, add (C) for cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,5 +19,7 @@ project(chrometracing VERSION 0.0)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+enable_testing()
+
 add_subdirectory(abseil-cpp)
 add_subdirectory(cc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cmake_minimum_required(VERSION 3.10)
 
 project(chrometracing VERSION 0.0)

--- a/cc/CMakeLists.txt
+++ b/cc/CMakeLists.txt
@@ -19,8 +19,6 @@ target_link_libraries(chrometracing absl::base absl::strings)
 target_include_directories(chrometracing PUBLIC
 	"${PROJECT_SOURCE_DIR}/abseil-cpp/absl")
 
-enable_testing()
-
 add_executable(chrometracing_init_test chrometracing_init_test.cc)
 target_link_libraries(chrometracing_init_test chrometracing absl::base absl::strings absl::time)
 add_test(init chrometracing_init_test)

--- a/cc/CMakeLists.txt
+++ b/cc/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 add_library(chrometracing
 	chrometracing.cc
 	compat.cc)


### PR DESCRIPTION
Update #1 

Looking through CI results from #3, I noticed that the C++ test runner exits with success without running any tests.

Move `enable_testing` into the top-level CMakeLists.txt.
