### PR TITLE
Make chrometracing_test.cc work

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "abseil-cpp"]
 	path = abseil-cpp
 	url = https://github.com/abseil/abseil-cpp
+[submodule "googletest"]
+	path = googletest
+	url = https://github.com/google/googletest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,16 @@ project(chrometracing VERSION 0.0)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+# Allow linking against libraries from other directories.
+cmake_policy(SET CMP0079 NEW)
+# Allow overriding options with a regular variable.
+cmake_policy(SET CMP0077 NEW)
+
 enable_testing()
 
+set(INSTALL_GTEST off CACHE BOOL "Install googletest")
+
 add_subdirectory(abseil-cpp)
+add_subdirectory(googletest)
 add_subdirectory(cc)
+

--- a/cc/CMakeLists.txt
+++ b/cc/CMakeLists.txt
@@ -23,5 +23,10 @@ add_executable(chrometracing_init_test chrometracing_init_test.cc)
 target_link_libraries(chrometracing_init_test chrometracing absl::base absl::strings absl::time)
 add_test(init chrometracing_init_test)
 
+add_executable(chrometracing_test chrometracing_test.cc)
+target_link_libraries(chrometracing_test chrometracing absl::base absl::strings absl::time gmock)
+add_test(chrometracing_test chrometracing_test)
+
+
 install(TARGETS chrometracing DESTINATION lib)
 install(FILES chrometracing.h DESTINATION include)

--- a/cc/chrometracing_test.cc
+++ b/cc/chrometracing_test.cc
@@ -14,8 +14,8 @@
 
 #include "chrometracing.h"
 
-#include "testing/base/public/gmock.h"
-#include "testing/base/public/gunit.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 namespace {
 
@@ -49,3 +49,9 @@ TEST(ChromeTracing, EventRenderCorrectly) {
 }
 
 }  // namespace
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleMock(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
Fixes #1

This also adds a vendored version of googletest for consistency.

In the future, I think we should have an option to use googletest and/or absl-cpp from the system.