### PR TITLE
Revert unintentional deletion of Flush method.

### DIFF
--- a/chrometracing.go
+++ b/chrometracing.go
@@ -225,3 +225,13 @@ func releaseTid(t uint64) {
 		tids.next = int(t)
 	}
 }
+
+// Flush should be called before your program terminates, and/or periodically
+// for long-running programs, to flush any pending chrome://tracing events out
+// to disk.
+func Flush() error {
+	if err := trace.file.Sync(); err != nil {
+		return fmt.Errorf("flushing trace file: %v", err)
+	}
+	return nil
+}


### PR DESCRIPTION
This is a "revert" of the deletions in 536f2aa8a76bb3e51c34ae4625860d1a92285b53 which appear to unintentionally and erroneously delete the `Flush` method.

It makes no other changes and is 1:1 with the original version.